### PR TITLE
fix chat owner tag alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,6 @@
 .ownertag {
     color: #fff;
+    left: 5px;
 }
 
 .ownertag-list {


### PR DESCRIPTION
fix this
![without fix](https://i.jaydensar.net/qYF3sdRK3B.png)
![with fix](https://i.jaydensar.net/e56AqbFDFu.png)

(Not sure if this is happening to everyone else or only just me. I cleared my QuickCSS and nothing changed so I assume Discord changed something. Didn't bother asking anyone if this was happening to anyone else, so)
