### PR TITLE
don't return null, don't break discord!

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ module.exports = class OwnerTag extends Plugin {
                 const guild = getGuild(channel.guild_id);
                 if (guild) {
                     const member = getMember(guild.id, id);
-                    if (!member) return null;
+                    if (!member) return res;
                     const permissions = getPermissionsRaw(guild, id);
                     const parsedPermissions = parseBitFieldPermissions(
                         permissions


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/31005896/97574597-c51db700-19eb-11eb-8429-849d875126ef.png)

if your plugin can't use component or find member doesn't mean that other plugins or discord can't.