### PR TITLE
Fix BigInt TypeError in getPermissionsRaw

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const parseBitFieldPermissions = allowed => {
     const permissions = {};
     for (const perm of Object.keys(Permissions)) {
         if (!perm.startsWith('all')) {
-            if (allowed & BigInt(Permissions[perm])) {
+            if (BigInt(allowed) & BigInt(Permissions[perm])) {
                 permissions[perm] = true;
             }
         }

--- a/index.js
+++ b/index.js
@@ -55,22 +55,25 @@ function getPermissionsRaw(guild, user_id) {
 
     if (guild && member) {
         if (guild.ownerId === user_id) {
-            permissions = Permissions.ADMINISTRATOR;
+            permissions = BigInt(Permissions.ADMINISTRATOR);
         } else {
             /* @everyone is not inlcuded in the member's roles */
             permissions |= BigInt(guild.roles[guild.id]?.permissions);
 
             for (const roleId of member.roles) {
-                permissions |= BigInt(guild.roles[roleId]?.permissions);
+                const role = guild.roles[roleId];
+                if (role !== undefined) {
+                    permissions |= BigInt(role.permissions);
+                }
             }
         }
 
         /* If they have administrator they have every permission */
         if (
             (BigInt(permissions) & BigInt(Permissions.ADMINISTRATOR)) ===
-            Permissions.ADMINISTRATOR
+            BigInt(Permissions.ADMINISTRATOR)
         ) {
-            return Object.values(Permissions).reduce((a, b) => a | b, 0n);
+            return Object.values(Permissions).reduce((a, b) => BigInt(a) | BigInt(b), 0n);
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -61,9 +61,9 @@ function getPermissionsRaw(guild, user_id) {
             permissions |= BigInt(guild.roles[guild.id]?.permissions);
 
             for (const roleId of member.roles) {
-                const role = guild.roles[roleId];
-                if (role !== undefined) {
-                    permissions |= BigInt(role.permissions);
+                const rolePerms = guild.roles[roleId]?.permissions;
+                if (rolePerms !== undefined) {
+                    permissions |= BigInt(rolePerms);
                 }
             }
         }

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ const DEFAULT_TAG_TEXTS = {
 };
 
 function getPermissionsRaw(guild, user_id) {
-    let permissions = 0;
+    let permissions = 0n;
 
     const member = getMember(guild.id, user_id);
 
@@ -70,7 +70,7 @@ function getPermissionsRaw(guild, user_id) {
             (permissions & Permissions.ADMINISTRATOR) ===
             Permissions.ADMINISTRATOR
         ) {
-            return Object.values(Permissions).reduce((a, b) => a | b, 0);
+            return Object.values(Permissions).reduce((a, b) => a | b, 0n);
         }
     }
 


### PR DESCRIPTION
Replace `0` with `0n` to avoid a TypeError about mixing BigInt with other types in the getPermissionsRaw() function