### PR TITLE
Add Per-Tag Crowns, fix tag colors settings

### DIFF
--- a/Components/Settings.jsx
+++ b/Components/Settings.jsx
@@ -92,10 +92,79 @@ module.exports = class Settings extends React.Component {
                     onChange={() => {
                         this.props.toggleSetting('showCrowns', false);
                     }}
-                    note='If enabled, Crowns will be displayed instead of Tags'
+                    note='Enable to select what Tags to replace with Crowns. Enable to show settings.'
                 >
                     Show crowns instead of Tags
                 </SwitchItem>
+
+                {this.props.getSetting('showCrowns') && (
+                    <>
+                        <SwitchItem
+                            value={this.props.getSetting(
+                                'showServerOwnerCrown',
+                                false
+                            )}
+                            onChange={() => {
+                                this.props.toggleSetting('showServerOwnerCrown');
+                            }}
+                            note='If enabled, Crowns will be displayed instead of Tags'
+                        >
+                            Show Server Owner Crown
+                        </SwitchItem>
+
+                        <SwitchItem
+                            value={this.props.getSetting(
+                                'showGroupOwnerCrown',
+                                false
+                            )}
+                            onChange={() => {
+                                this.props.toggleSetting('showGroupOwnerCrown');
+                            }}
+                            note='If enabled, Crowns will be displayed instead of Tags'
+                        >
+                            Show Group Owner Crown
+                        </SwitchItem>
+
+                        <SwitchItem
+                            value={this.props.getSetting(
+                                'showAdminCrown',
+                                false
+                            )}
+                            onChange={() => {
+                                this.props.toggleSetting('showAdminCrown');
+                            }}
+                            note='If enabled, Crowns will be displayed instead of Tags'
+                        >
+                            Show Admin Crown
+                        </SwitchItem>
+
+                        <SwitchItem
+                            value={this.props.getSetting(
+                                'showStaffCrown',
+                                false
+                            )}
+                            onChange={() => {
+                                this.props.toggleSetting('showStaffCrown');
+                            }}
+                            note='If enabled, Crowns will be displayed instead of Tags'
+                        >
+                            Show Staff Crown
+                        </SwitchItem>
+
+                        <SwitchItem
+                            value={this.props.getSetting(
+                                'showModCrown',
+                                false
+                            )}
+                            onChange={() => {
+                                this.props.toggleSetting('showModCrown');
+                            }}
+                            note='If enabled, Crowns will be displayed instead of Tags'
+                        >
+                            Show Mod Crown
+                        </SwitchItem>
+                    </>
+                )}
 
                 <SwitchItem
                     value={this.props.getSetting('displayMembers', true)}

--- a/Components/Settings.jsx
+++ b/Components/Settings.jsx
@@ -230,12 +230,11 @@ module.exports = class Settings extends React.Component {
                             <SwitchItem
                                 value={this.props.getSetting(
                                     'GroupOwnerColor',
-                                    true
+                                    false
                                 )}
                                 onChange={() => {
                                     this.props.toggleSetting(
-                                        'GroupOwnerColor',
-                                        true
+                                        'GroupOwnerColor'
                                     );
                                 }}
                                 note='If enabled, Group Owner tag color will be same as Server Owner tag color'

--- a/changelog.json
+++ b/changelog.json
@@ -1,17 +1,12 @@
 {
-    "date": "2022-08-23",
-    "image": "https://c.tenor.com/4blWuIh5MIYAAAAC/baby-yoda.gif",
+    "date": "2022-08-30",
+    "image": "https://c.tenor.com/YE66dMAuat4AAAAC/star-wars.gif",
     "body": [
-        {
-            "type": "fixed",
-            "header": "Fixed",
-            "content": ["- **Owner Tag** Fixed `showOwnerTag` setting."]
-        },
         {
             "type": "added",
             "header": "Added",
             "content": [
-                "- **Bot Tags** Bot tags will now show in chat when `showForBots` setting is enabled."
+                "- **Per-Tag Crowns** You can now choose which tags to replace with crowns."
             ]
         }
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -5,7 +5,10 @@
         {
             "type": "fixed",
             "header": "Fixed",
-            "content": ["- **Group Owner Tag** Fixed disabling `Use Custom Group owner Color` not taking effect."]
+            "content": [
+                "- **Group Owner Tag** Fixed disabling `Use Custom Group owner Color` not taking effect.",
+                "- **Custom Tag Colors** Fixed disabling `Change Tag Colors` not disabling enabled tag colors."
+            ]
         },
         {
             "type": "added",

--- a/changelog.json
+++ b/changelog.json
@@ -3,6 +3,11 @@
     "image": "https://c.tenor.com/YE66dMAuat4AAAAC/star-wars.gif",
     "body": [
         {
+            "type": "fixed",
+            "header": "Fixed",
+            "content": ["- **Group Owner Tag** Fixed disabling `Use Custom Group owner Color` not taking effect."]
+        },
+        {
             "type": "added",
             "header": "Added",
             "content": [

--- a/index.js
+++ b/index.js
@@ -167,6 +167,7 @@ module.exports = class StaffTags extends Plugin {
                         e.props.children.find(c => c?.props?.message)
                 );
                 if (!header) return res;
+                let showCrowns;
                 let data;
 
                 const channel = args[0].channel;
@@ -189,6 +190,9 @@ module.exports = class StaffTags extends Plugin {
                         const useCustomColor = _this.settings.get(
                             'useCustomOwnerColor'
                         );
+                        showCrowns = _this.settings.get(
+                            'showServerOwnerCrown'
+                        );
                         data = {
                             userType: _this.settings.get('showOwnerTags', true)
                                 ? userTypes.SOWNER
@@ -210,6 +214,9 @@ module.exports = class StaffTags extends Plugin {
                         );
                         const useCustomColor = _this.settings.get(
                             'useCustomAdminColor'
+                        );
+                        showCrowns = _this.settings.get(
+                            'showAdminCrown'
                         );
                         data = {
                             userType: _this.settings.get('showAdminTags', true)
@@ -237,6 +244,9 @@ module.exports = class StaffTags extends Plugin {
                         const useCustomColor = _this.settings.get(
                             'useCustomStaffColor'
                         );
+                        showCrowns = _this.settings.get(
+                            'showStaffCrown'
+                        );
                         data = {
                             userType: _this.settings.get('showStaffTags', true)
                                 ? userTypes.STAFF
@@ -262,6 +272,9 @@ module.exports = class StaffTags extends Plugin {
                         );
                         const useCustomColor =
                             _this.settings.get('useCustomModColor');
+                        showCrowns = _this.settings.get(
+                            'showModCrown'
+                        );
                         data = {
                             userType: _this.settings.get('showModTags', true)
                                 ? userTypes.MOD
@@ -286,6 +299,9 @@ module.exports = class StaffTags extends Plugin {
                     const useCustomColor = _this.settings.get(
                         'useCustomOwnerColor'
                     );
+                    showCrowns = _this.settings.get(
+                        'showGroupOwnerCrown'
+                    );
                     data = {
                         userType: userTypes.GOWNER,
                         color: useCustomColor && tagColor ? tagColor : null
@@ -295,7 +311,7 @@ module.exports = class StaffTags extends Plugin {
                 //const element = React.createElement(Tag, { userid: id });
                 if (data && data.userType !== userTypes.NONE) {
                     // const textColor = _this.settings.get('textColor');
-                    if (_this.settings.get('showCrowns', false)) {
+                    if (_this.settings.get('showCrowns', false) && showCrowns) {
                         const element = React.createElement(
                             Tooltip,
                             {
@@ -388,6 +404,7 @@ module.exports = class StaffTags extends Plugin {
                             return res;
                         }
 
+                        let showCrowns;
                         let data;
 
                         const id = user.id;
@@ -406,6 +423,9 @@ module.exports = class StaffTags extends Plugin {
                                 );
                                 const useCustomColor = _this.settings.get(
                                     'useCustomOwnerColor'
+                                );
+                                showCrowns = _this.settings.get(
+                                    'showServerOwnerCrown'
                                 );
                                 data = {
                                     userType: _this.settings.get(
@@ -431,6 +451,9 @@ module.exports = class StaffTags extends Plugin {
                                 );
                                 const useCustomColor = _this.settings.get(
                                     'useCustomAdminColor'
+                                );
+                                showCrowns = _this.settings.get(
+                                    'showAdminCrown'
                                 );
                                 data = {
                                     userType: _this.settings.get(
@@ -461,6 +484,9 @@ module.exports = class StaffTags extends Plugin {
                                 const useCustomColor = _this.settings.get(
                                     'useCustomStaffColor'
                                 );
+                                showCrowns = _this.settings.get(
+                                    'showStaffCrown'
+                                );
                                 data = {
                                     userType: _this.settings.get(
                                         'showStaffTags',
@@ -489,6 +515,9 @@ module.exports = class StaffTags extends Plugin {
                                 );
                                 const useCustomColor =
                                     _this.settings.get('useCustomModColor');
+                                showCrowns = _this.settings.get(
+                                    'showModCrown'
+                                );
                                 data = {
                                     userType: _this.settings.get(
                                         'showModTags',
@@ -519,6 +548,9 @@ module.exports = class StaffTags extends Plugin {
                             const useCustomColor = _this.settings.get(
                                 'useCustomOwnerColor'
                             );
+                            showCrowns = _this.settings.get(
+                                'showGroupOwnerCrown'
+                            );
                             data = {
                                 userType: userTypes.GOWNER,
                                 color:
@@ -527,7 +559,7 @@ module.exports = class StaffTags extends Plugin {
                         }
 
                         if (data && data.userType !== userTypes.NONE) {
-                            if (_this.settings.get('showCrowns', false)) {
+                            if (_this.settings.get('showCrowns', false) && showCrowns) {
                                 const element = React.createElement(
                                     Tooltip,
                                     {

--- a/index.js
+++ b/index.js
@@ -297,7 +297,7 @@ module.exports = class StaffTags extends Plugin {
                         '#ED9F1B'
                     );
                     const useCustomColor = _this.settings.get(
-                        'useCustomOwnerColor'
+                        'GroupOwnerColor'
                     );
                     showCrowns = _this.settings.get(
                         'showGroupOwnerCrown'
@@ -546,7 +546,7 @@ module.exports = class StaffTags extends Plugin {
                                 '#ED9F1B'
                             );
                             const useCustomColor = _this.settings.get(
-                                'useCustomOwnerColor'
+                                'GroupOwnerColor'
                             );
                             showCrowns = _this.settings.get(
                                 'showGroupOwnerCrown'

--- a/index.js
+++ b/index.js
@@ -188,8 +188,8 @@ module.exports = class StaffTags extends Plugin {
                             '#ED9F1B'
                         );
                         const useCustomColor = _this.settings.get(
-                            'useCustomOwnerColor'
-                        );
+                            'customTagColors') &&
+                            _this.settings.get('useCustomOwnerColor');
                         showCrowns = _this.settings.get(
                             'showServerOwnerCrown'
                         );
@@ -213,8 +213,8 @@ module.exports = class StaffTags extends Plugin {
                             '#B4B4B4'
                         );
                         const useCustomColor = _this.settings.get(
-                            'useCustomAdminColor'
-                        );
+                            'customTagColors') &&
+                            _this.settings.get('useCustomAdminColor');
                         showCrowns = _this.settings.get(
                             'showAdminCrown'
                         );
@@ -242,8 +242,8 @@ module.exports = class StaffTags extends Plugin {
                             '#8D5C51'
                         );
                         const useCustomColor = _this.settings.get(
-                            'useCustomStaffColor'
-                        );
+                            'customTagColors') &&
+                            _this.settings.get('useCustomStaffColor');
                         showCrowns = _this.settings.get(
                             'showStaffCrown'
                         );
@@ -271,6 +271,7 @@ module.exports = class StaffTags extends Plugin {
                             '#C8682E'
                         );
                         const useCustomColor =
+                            _this.settings.get('customTagColors') &&
                             _this.settings.get('useCustomModColor');
                         showCrowns = _this.settings.get(
                             'showModCrown'
@@ -297,8 +298,8 @@ module.exports = class StaffTags extends Plugin {
                         '#ED9F1B'
                     );
                     const useCustomColor = _this.settings.get(
-                        'GroupOwnerColor'
-                    );
+                        'customTagColors') &&
+                        _this.settings.get('GroupOwnerColor');
                     showCrowns = _this.settings.get(
                         'showGroupOwnerCrown'
                     );
@@ -422,8 +423,8 @@ module.exports = class StaffTags extends Plugin {
                                     '#ED9F1B'
                                 );
                                 const useCustomColor = _this.settings.get(
-                                    'useCustomOwnerColor'
-                                );
+                                    'customTagColors') &&
+                                    _this.settings.get('useCustomOwnerColor');
                                 showCrowns = _this.settings.get(
                                     'showServerOwnerCrown'
                                 );
@@ -450,8 +451,8 @@ module.exports = class StaffTags extends Plugin {
                                     '#B4B4B4'
                                 );
                                 const useCustomColor = _this.settings.get(
-                                    'useCustomAdminColor'
-                                );
+                                    'customTagColors') &&
+                                    _this.settings.get('useCustomAdminColor');
                                 showCrowns = _this.settings.get(
                                     'showAdminCrown'
                                 );
@@ -482,8 +483,8 @@ module.exports = class StaffTags extends Plugin {
                                     '#8D5C51'
                                 );
                                 const useCustomColor = _this.settings.get(
-                                    'useCustomStaffColor'
-                                );
+                                    'customTagColors') &&
+                                    _this.settings.get('useCustomStaffColor');
                                 showCrowns = _this.settings.get(
                                     'showStaffCrown'
                                 );
@@ -514,6 +515,7 @@ module.exports = class StaffTags extends Plugin {
                                     '#C8682E'
                                 );
                                 const useCustomColor =
+                                    _this.settings.get('customTagColors') &&
                                     _this.settings.get('useCustomModColor');
                                 showCrowns = _this.settings.get(
                                     'showModCrown'
@@ -546,8 +548,8 @@ module.exports = class StaffTags extends Plugin {
                                 '#ED9F1B'
                             );
                             const useCustomColor = _this.settings.get(
-                                'GroupOwnerColor'
-                            );
+                                'customTagColors') &&
+                                _this.settings.get('GroupOwnerColor');
                             showCrowns = _this.settings.get(
                                 'showGroupOwnerCrown'
                             );

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Staff Tags",
-    "version": "1.0.17",
+    "version": "1.0.18",
     "description": "Adds a tag or crown to Owners, Mods, Admins and Staff.",
     "author": "Puyodead1",
     "license": "MIT"


### PR DESCRIPTION
- Adds crown settings to each tag
- Fixes disabling of `Use Custom Group owner Color` and `Change Tag Colors` settings

Known issue (minor I suppose + this is a problem without this PR too I believe):
`Use Custom Group owner Color` value had to be changed to `false` because `Use Custom Owner Color` would not actually automatically activate `Use Custom Group owner Color`. The group owner setting only appeared visually enabled. In order to take effect the setting had to be manually disabled and enabled. The change of default value from `true` to `false` is still better than the setting not working (in effect always being forced to on) in my opinion.

If anyone knows how to fix this so that `Use Custom Group owner Color` can be properly set to `true` by default please submit an edit/suggestion.